### PR TITLE
Tweak The Time Game

### DIFF
--- a/NOTES.txt
+++ b/NOTES.txt
@@ -1,3 +1,6 @@
+// implement non-blocking delay and use it to speed up repeated slots play (press to bypass cash display)
+
+
 // minimum reaction time (or a bug?) is 50ms
 // time game choose a color and the average is stored with it, allowing for three profiles
 

--- a/include/led_handler.h
+++ b/include/led_handler.h
@@ -3,6 +3,10 @@
 
 // for STYLE_MIRROR, the secondary LEDs mirroring the first are expected to be in the upper half of the set of LED pins
 
+#define FLASH_STATE_START 0
+#define FLASH_STATE_RUN   1
+#define FLASH_STATE_DONE  2
+
 class LEDHandler
 {
 public:
@@ -15,6 +19,9 @@ public:
 	void deactivate_leds(bool mirror=false);
 	void flash_leds(bool mirror=false, long time=0);
 
+	void begin_flash(bool mirror, int on_time);
+	bool step_flash(unsigned long time);
+
 	static const int STYLE_PLAIN    = 0x00; // one LED at a time sequentially
 	static const int STYLE_RANDOM   = 0x01; // one LED at a time randomly
 	static const int STYLE_BLANKING = 0x02; // blanking period between LED activations
@@ -23,7 +30,7 @@ public:
 
 	static const int DEFAULT_SHOW_TIME  = 250;
 	static const int DEFAULT_BLANK_TIME = 250;
-	static const int DEFAULT_FLASH_TIME = 25; //50;
+	static const int DEFAULT_FLASH_TIME = 100; //50;
 
 private:
 	void deactivate_led(int virtual_pin, bool mirror=false);
@@ -41,9 +48,13 @@ private:
 	int _num_frames;
 	int _num_states;
 	bool _blanking;
-	char _active;
-		   // virtual current active led or other state
+	char _active;			// virtual current active led or other state
 
+	bool _flash_mirror;
+	int _flash_on_time;
+	bool _flash_state;
+	int _flash_pins;
+	unsigned long _next_flash_change;
 };
 
 #endif

--- a/include/leds.h
+++ b/include/leds.h
@@ -12,7 +12,7 @@
 #define DEFAULT_BUTTON_LEDS_BLANK_TIME 400
 #define TITLE_PANEL_LEDS_SHOW_TIME     100
 #define TITLE_PANEL_LEDS_BLANK_TIME    0
-#define TITLE_PANEL_LEDS_STYLE (LEDHandler::STYLE_PLAIN)
+#define TITLE_PANEL_LEDS_STYLE (LEDHandler::STYLE_RANDOM)
 
 #define LED_INTENSITY1 32 // Green panel LED is a bit brighter than the Amber and Red LEDs
 #define LED_INTENSITY2 40 // Amber panel LED matched to Green

--- a/include/speaker.h
+++ b/include/speaker.h
@@ -4,7 +4,7 @@
 #define INV_FREQUENCY 339
 #define BEEP_PULSES 90
 #define BEEPS_TIMES 4
-#define ALERT_TIMES 2
+#define ALERT_TIMES 3
 #define ALERT_DELAY 600
 
 extern void beep(int inv_freq = INV_FREQUENCY, int pulses = BEEP_PULSES);

--- a/include/time_game.h
+++ b/include/time_game.h
@@ -2,7 +2,7 @@
 #define __TIME_GAME_H
 
 #define MIN_DELAY 2500
-#define MAX_DELAY 6000
+#define MAX_DELAY 5000
 #define ROUNDS 3
 #define TIME_WIN 1000
 

--- a/src/led_handler.cpp
+++ b/src/led_handler.cpp
@@ -136,3 +136,38 @@ void LEDHandler::flash_leds(bool mirror, long time){
 			digitalWrite(virtual_pin + _first_pin + (_num_leds / 2), LOW);
 	}
 }
+
+// flash the LEDs at full intensity, non-blocking
+void LEDHandler::begin_flash(bool mirror, int on_time){
+	_flash_mirror = mirror;
+	_flash_pins = mirror ? (_num_leds / 2) : _num_leds;
+
+	for(int virtual_pin = 0; virtual_pin < _flash_pins; virtual_pin++){
+		digitalWrite(virtual_pin + _first_pin, HIGH);
+		if(_flash_mirror)
+			digitalWrite(virtual_pin + _first_pin + (_num_leds / 2), HIGH);
+	}
+
+	_flash_on_time = on_time != 0 ? on_time : DEFAULT_FLASH_TIME;
+	_flash_state = true;
+	_next_flash_change = millis() + _flash_on_time;
+}
+
+// returns true to keep going
+bool LEDHandler::step_flash(unsigned long time){
+	if(!_flash_state)
+		// already done flashing
+		return false;
+
+	if(time < _next_flash_change)
+		// not time yet to stop flash
+		return true;
+
+	// currently on, turn off
+	for(int virtual_pin = 0; virtual_pin < _flash_pins; virtual_pin++){
+		digitalWrite(virtual_pin + _first_pin, LOW);
+		if(_flash_mirror)
+			digitalWrite(virtual_pin + _first_pin + (_num_leds / 2), LOW);
+	}
+	_flash_state = false;
+}

--- a/src/time_game.cpp
+++ b/src/time_game.cpp
@@ -15,7 +15,7 @@ void time_game(){
 
 	int response;
 	const bool buttons[] = {false, true, false, true};
-	response = button_led_prompt(FSTR("START   Back"), buttons);
+	response = button_led_prompt(FSTR(" GO     Back"), buttons);
 	if(response == 0 || response == -1 || response == RED_ID)
 		return;
 
@@ -40,10 +40,10 @@ void time_game(){
 			;
 		}
 
+		panel_leds.begin_flash(false, 0);
 		unsigned long start_time = micros();
 
 		// panel_leds.flash_leds();
-		panel_leds.begin_flash(false, 0);
 		panel_leds.step_flash(millis());
 
 		// if(digitalRead(ANY_BUTTON) == HIGH){
@@ -62,7 +62,7 @@ void time_game(){
 
 		unsigned long reaction_time = micros() - start_time;
 		while(digitalRead(ANY_BUTTON) == HIGH)
-			;
+			panel_leds.step_flash(millis());
 
 		mean += reaction_time;
 
@@ -106,5 +106,6 @@ void time_game(){
 		sprintf(display_buffer, FSTR("* Best Time %s ms"), copy_buffer);
 	}
 
-	while(button_led_prompt(display_buffer) == -1);
+	// while(button_led_prompt(display_buffer) == -1);
+	button_led_prompt(display_buffer);
 }


### PR DESCRIPTION
The panel LED flash sometimes triggers a button press. And the time measured shows up as the flash time.
- make flashing non-blocking
- tolerate unexpected button presses
- add some debugging info capture

Also the maximum 6 second delay seemed to long to wait for the flash.