### PR TITLE
Improve Slot Reels, Auto Play bonus feature

### DIFF
--- a/include/play_data.h
+++ b/include/play_data.h
@@ -102,6 +102,8 @@ extern byte option_clock_chime;
 
 extern byte option_wpm;
 
+extern bool auto_play_enabled;
+
 // ##DATA Add 'extern's for new persisted play data veriables here
 
 
@@ -125,6 +127,7 @@ struct SavedData{
     bool option_vib_str;
     byte option_clock_chime;
     byte option_wpm;
+    bool auto_play_enabled;
 
 	// ##DATA Add new persisted data types above here
 };

--- a/include/slot_game.h
+++ b/include/slot_game.h
@@ -3,7 +3,7 @@
 
 // For animating the slot machine wheels, the show time (20ms) before scrolling and the scrolling time (every 20ms)
 #define SLOTS_SHOW_TIME   1
-#define SLOTS_SCROLL_TIME 20
+#define SLOTS_SCROLL_TIME 19
 
 #define BONUS_SHOW_TIME 1500
 
@@ -23,7 +23,15 @@
 // Default best on power-up
 #define DEFAULT_BET 10
 
+#ifndef USE_ALL_WORDS
+#define REEL_WORDS 10
+#define REEL_BUFFER_LEN (4 + (REEL_WORDS * 6) + 1)
+#else
 #define REEL_BUFFER_LEN (2 + (NUM_WORDS * 6) + 1)
+#endif
+
+#define AUTOPLAY_SHOW_TIME 1000
+#define AUTOPLAY_BLANK_TIME 500
 
 extern byte choice1, choice2, choice3;
 

--- a/include/slot_game.h
+++ b/include/slot_game.h
@@ -32,6 +32,7 @@
 
 #define AUTOPLAY_SHOW_TIME 1000
 #define AUTOPLAY_BLANK_TIME 500
+#define AUTOPLAY_LEDS_TIME 500
 
 extern byte choice1, choice2, choice3;
 

--- a/include/utils.h
+++ b/include/utils.h
@@ -16,5 +16,6 @@ extern bool title_prompt_int(const char * pattern, int data, bool show_leds = fa
 extern bool title_prompt_string(const char * pattern, const char * data, bool show_leds = false, int show_time = 0);
 extern bool title_prompt_string2(const char * pattern, const char * data1, const char * data2, bool show_leds = false, int show_time = 0);
 extern bool title_prompt_string3(const char * pattern, const char * data1, const char * data2, const char * data3, bool show_leds = false, int show_time = 0);
+extern void random_unique(int count, int max_value, int *result);
 
 #endif

--- a/src/bank.cpp
+++ b/src/bank.cpp
@@ -78,6 +78,7 @@ long bank_robbery(long min_money, long max_money){
 
 #define RESETTING_SHOW_TIMES 2
 #define RESETTING_COUNTDOWN_TIME 450
+#define RESET_BONUS (1000000000L / MONEY_BASIS)
 
 bool reset_bank(){
     title_prompt(FSTR("BANK INSOLVANT. RESETTING"), RESETTING_SHOW_TIMES);
@@ -90,11 +91,12 @@ bool reset_bank(){
         delay(RESETTING_COUNTDOWN_TIME);
     }
 
-	purse = DEFAULT_PURSE;
-	bank = DEFAULT_BANK;
+	purse = DEFAULT_PURSE + RESET_BONUS;
+	bank = DEFAULT_BANK - RESET_BONUS;
 	house = DEFAULT_HOUSE;
 	gang = DEFAULT_GANG;
     vig = DEFAULT_VIG;
+    auto_play_enabled = true;
 
     // ##DATA Reset new persisted play data veriables to default variables here
 

--- a/src/led_handler.cpp
+++ b/src/led_handler.cpp
@@ -86,7 +86,7 @@ void LEDHandler::step(unsigned long time){
 	bool blanking_period = (_style & STYLE_BLANKING) && (_frame % 2);
 	if(!blanking_period){
 		if(_style & STYLE_RANDOM){
-			int r; // skkp prevention llgic here if neing e abled
+			int r; // skip prevention logic here if nothing enabled
 			while( (r = random(_num_states)) == _active )
 				;
 			_active = r;

--- a/src/options_mode.cpp
+++ b/src/options_mode.cpp
@@ -83,7 +83,7 @@ bool options_menu(){
 
     option_wpm = prompt_wpm(option_wpm);
 
-    sprintf_P(copy_buffer, PSTR("%d WPM"), option_wpm);
+    sprintf_P(copy_buffer, PSTR("WPM %d"), option_wpm);
     send_morse(copy_buffer);
 
 	save_data();

--- a/src/play_data.cpp
+++ b/src/play_data.cpp
@@ -22,8 +22,9 @@ long vig = DEFAULT_VIG;
 bool option_vib_str;
 byte option_clock_chime;
 byte option_wpm;
+bool auto_play_enabled;
 
-// ##DATA Add new persisted play data veriables here
+// ##DATA Add new persisted play data veriables above here
 
 void load_save_data(){
 	SavedData saved_data;
@@ -51,6 +52,7 @@ void load_save_data(){
     option_vib_str = saved_data.option_vib_str;
     option_clock_chime = saved_data.option_clock_chime;
     option_wpm = saved_data.option_wpm;
+    auto_play_enabled = saved_data.auto_play_enabled;
 
 	// ##DATA Load new persisted play data variables into memory here
 }
@@ -75,6 +77,7 @@ void save_data(){
     saved_data.option_vib_str = option_vib_str;
     saved_data.option_clock_chime = option_clock_chime;
     saved_data.option_wpm = option_wpm;
+    saved_data.auto_play_enabled = auto_play_enabled;
 
 	// ##DATA Store new persisted play data veriables in the persistent structure here
 
@@ -106,6 +109,7 @@ bool reset_options(){
     option_vib_str = DEFAULT_VIB_STR;
     option_clock_chime = DEFAULT_CLOCK_CHIME;
     option_wpm = DEFAULT_WPM;
+    auto_play_enabled = false;
 
 	// ##DATA Reset new persisted play data veriables to default variables here
 

--- a/src/slot_game.cpp
+++ b/src/slot_game.cpp
@@ -148,7 +148,7 @@ bool slots_game(){
             delay(AUTOPLAY_BLANK_TIME);
             current_bet = (bet_amounts[BET_ALL] > bet_amounts[BET_REPEAT]) ? BET_ALL : BET_REPEAT;
             sprintf_P(display_buffer, PSTR("AUTO BET $%s"), format_long(bet_amounts[current_bet]));
-            if(title_prompt(display_buffer, 1, true, AUTOPLAY_SHOW_TIME, LEDHandler::STYLE_PLAIN)){
+            if(title_prompt(display_buffer, 1, true, AUTOPLAY_SHOW_TIME, LEDHandler::STYLE_RANDOM, AUTOPLAY_LEDS_TIME)){
                 return false;
             }
         } else {

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -84,3 +84,19 @@ bool title_prompt_string3(const char * pattern, const char * data1, const char *
 	sprintf(display_buffer, pattern, data1, data2, data3);
 	return title_prompt(display_buffer, 1, show_leds, show_time == 0 ? ROUND_DELAY : show_time);
 }
+
+void random_unique(int count, int max_value, int *result){
+    for(int i = 0; i < count; i++){
+        bool found = false;
+        while(!found){
+            result[i] = random(max_value);
+            found = true;
+            for(int j = 0; j < i; j++){
+                if(result[i] == result[j]){
+                    found = false;
+                    break;
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Now that there are 15 words, the spinning reels either took too long, or moved to fast to be acceptable for play. Instead, the original 10 word reel word format is used with 10 words random selected each time the game is invoked.

Also, there is now an auto-play feature activated by long pressing the "Back" option of the betting prompt. It is enabled only after the bank has been broken.

Breaking the bank requires causing the bank to have less than $1B in funds out of the original $100B. Doing do gives you:
* $1B bonus cash
* Unlocked Auto-Play feature
